### PR TITLE
Release/0.1.0

### DIFF
--- a/.idea/personal-api.iml
+++ b/.idea/personal-api.iml
@@ -45,6 +45,7 @@
     <orderEntry type="library" scope="PROVIDED" name="bootsnap (v1.16.0, rbenv: 3.1.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="builder (v3.2.4, rbenv: 3.1.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="bundler (v2.4.20, rbenv: 3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="coderay (v1.1.3, rbenv: 3.1.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="concurrent-ruby (v1.2.2, rbenv: 3.1.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="connection_pool (v2.4.1, rbenv: 3.1.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="crass (v1.0.6, rbenv: 3.1.2) [gem]" level="application" />
@@ -55,6 +56,8 @@
     <orderEntry type="library" scope="PROVIDED" name="drb (v2.1.1, rbenv: 3.1.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="error_highlight (v0.5.1, rbenv: 3.1.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="erubi (v1.12.0, rbenv: 3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="factory_bot (v6.2.1, rbenv: 3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="factory_bot_rails (v6.2.0, rbenv: 3.1.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="ffaker (v2.23.0, rbenv: 3.1.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="globalid (v1.2.1, rbenv: 3.1.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="i18n (v1.14.1, rbenv: 3.1.2) [gem]" level="application" />
@@ -66,6 +69,7 @@
     <orderEntry type="library" scope="PROVIDED" name="loofah (v2.21.4, rbenv: 3.1.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="mail (v2.8.1, rbenv: 3.1.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="marcel (v1.0.2, rbenv: 3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="method_source (v1.0.0, rbenv: 3.1.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="mini_mime (v1.1.5, rbenv: 3.1.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="minitest (v5.20.0, rbenv: 3.1.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="msgpack (v1.7.2, rbenv: 3.1.2) [gem]" level="application" />
@@ -79,6 +83,7 @@
     <orderEntry type="library" scope="PROVIDED" name="parallel (v1.23.0, rbenv: 3.1.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="parser (v3.2.2.4, rbenv: 3.1.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="pg (v1.5.4, rbenv: 3.1.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="pry (v0.14.2, rbenv: 3.1.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="psych (v5.1.1.1, rbenv: 3.1.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="public_suffix (v5.0.3, rbenv: 3.1.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="puma (v6.4.0, rbenv: 3.1.2) [gem]" level="application" />

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,9 @@ gem 'tzinfo-data', platforms: %i[mswin mswin64 mingw x64_mingw jruby]
 
 group :development, :test do
   gem 'debug', platforms: %i[mri mswin mswin64 mingw x64_mingw]
+  gem 'factory_bot_rails', '~> 6.2'
   gem 'ffaker', '~> 2.23'
+  gem 'pry', '~> 0.14.1'
   gem 'rspec-rails'
   gem 'rswag-specs'
   gem 'rubocop', '~> 1.57', '>= 1.57.1', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,7 @@ GEM
     bootsnap (1.16.0)
       msgpack (~> 1.2)
     builder (3.2.4)
+    coderay (1.1.3)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
     crass (1.0.6)
@@ -95,6 +96,11 @@ GEM
       ruby2_keywords
     error_highlight (0.5.1)
     erubi (1.12.0)
+    factory_bot (6.2.1)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.2.0)
+      factory_bot (~> 6.2.0)
+      railties (>= 5.0.0)
     ffaker (2.23.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
@@ -117,6 +123,7 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.2)
+    method_source (1.0.0)
     mini_mime (1.1.5)
     minitest (5.20.0)
     msgpack (1.7.2)
@@ -138,6 +145,9 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.4)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     psych (5.1.1.1)
       stringio
     public_suffix (5.0.3)
@@ -257,8 +267,10 @@ DEPENDENCIES
   bootsnap
   debug
   error_highlight (>= 0.4.0)
+  factory_bot_rails (~> 6.2)
   ffaker (~> 2.23)
   pg (~> 1.1)
+  pry (~> 0.14.1)
   puma (>= 5.0)
   rack-cors
   rails (~> 7.1.1)

--- a/config/application.rb
+++ b/config/application.rb
@@ -41,6 +41,17 @@ module PersonalApi
     # Only loads a smaller set of middleware suitable for API only apps.
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
+
+    config.generators do |g|
+      g.test_framework :rspec, fixture: true
+      g.fixture_replacement :factory, dir: 'spec/factories'
+      g.view_specs = false
+      g.helper_specs = false
+      g.stylesheets = false
+      g.javascripts = false
+      g.helper = false
+    end
+    config.autoload_paths << Rails.root.join('lib')
     config.api_only = true
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 Rails.application.routes.draw do
   mount Rswag::Ui::Engine => '/api-docs'
   mount Rswag::Api::Engine => '/api-docs'
@@ -8,7 +6,8 @@ Rails.application.routes.draw do
   get 'up' => 'rails/health#show', as: :rails_health_check
 
   namespace :api, defaults: { format: :json }, constraints: { subdomain: 'api' }, path: '/' do
-
+    # scope module: :v1, constraints: ApiConstraints.new(version: 1, default: true) do
+    # todo: resources :users, only: %i[show create update destroy]
+    # end
   end
-  # root "posts#index"
 end

--- a/lib/api_constraints.rb
+++ b/lib/api_constraints.rb
@@ -1,0 +1,12 @@
+class ApiConstraints
+  attr_reader :version, :default
+
+  def initialize(options)
+    @version = options[:version]
+    @default = options[:default]
+  end
+
+  def matches?(request)
+    @default || request.headers['Accept'].include?("application/personal-api.v#{@version}")
+  end
+end

--- a/lib/spec/api_constraints_spec.rb
+++ b/lib/spec/api_constraints_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+describe ApiConstraints do
+  let(:api_constraint_v1) { ApiConstraints.new(version: 1) }
+  let(:api_constraint_v2) { ApiConstraints.new(version: 2) }
+
+  describe 'matches?' do
+    it "Returns true when the version matches 'Accept' header" do
+      request = double(host: 'localhost:3000', headers: { 'Accept' => 'application/personal-api.v1' })
+      expect(api_constraint_v1.matches?(request)).to be_truthy
+    end
+
+    it 'Returns default' do
+      request = double('request', headers: { 'Accept' => 'application/personal-api.v2' })
+      expect(api_constraint_v2.matches?(request)).to be_truthy
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,7 +5,7 @@ ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 ENV['RAILS_ENV'] ||= 'test'
-require_relative '..config/environment'
+require_relative '../config/environment'
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
 


### PR DESCRIPTION
# All API versioning context for version v1, v2, etc

## Introduction

API versioning is the process of assigning a version number to an API. This allows consumers of the API to identify which version they are using and to make sure that they are compatible with the changes that have been made to the API.

## Approaches

There are several different ways to version an API. The most common approach is to use a version number in the API endpoint. For example, an API that returns a list of products might have the following endpoints:

/articles/v1
/articles/v2

This approach is easy to understand and use, but it can be difficult to manage if you have a large number of versions.

Another approach is to use a header in the HTTP request. For example, an API might use the following header to specify the version:

Accept: application/json; version=2
?version=2
This approach is the least common, but it can be useful for APIs that need to support a large number of versions.

## Best Practices

In general, it is best to use a versioning approach that is easy to understand and use for both consumers and developers of the API.

Here are some additional tips for versioning APIs:

* Use a semantic versioning scheme. This will help consumers of the API to understand the significance of changes between versions.
* Document the API versions that you support. This will help consumers of the API to choose the right version for their needs.
* Test your API against different versions. This will help you to ensure that your API is compatible with older versions.

## Conclusion

API versioning is an important part of API design. By choosing the right approach and following best practices, you can make it easy for consumers to use your API and ensure that it is compatible with future changes.
